### PR TITLE
Typos, config changes, conda fixes, bugs squashed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /datasets/
-/conda/cache
+/conda/envs
 /configs/aws.config
 .nextflow*
 /work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # bactopia/bactopia: Changelog
 
+## v1.2.1 bactopia/bactopia "Fruit Punches" - 2019/10/17
+
+### `Added`
+- `bactopia build` to build Conda environments
+- Version info pulled from nextflow.config
+- Set default values resource allocations
+- Documentation on new changes
+- Automatic building of Conda environments, if none exist
+- `--nfdir` to determine where bactopia is being run from
+
+### `Fixed`
+- Neverending typos
+- `--datasets` now, not `--dataset` <-(Typo)
+- path for outputing Nextflow reports
+- Typo in antimicrobial_resistance.sh (task.cpus not cpus)
+- `--species` is now consistent between `bactopia` and `bactopia datasets`
+- Bug when checking if specific species dataset exists, but no species datasets exist
+- Cleaned up version update script
+- Cleaned up usage
+
+### `Removed`
+- `--max_cpus` ability to limit total cores used, access to config is being deprecated in Nextflow
+- `--max_cpus` since it is redudant to `--cpus` now
+
 ## v1.2.0 bactopia/bactopia "Beestinger" - 2019/10/16
 
 ### `Added`

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ LABEL version="1.2.0"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image for Bactopia"
 
-RUN conda create -n bactopia -c conda-forge -c bioconda bactopia && conda clean -a
+RUN conda create -n bactopia -c conda-forge -c bioconda bactopia=1.2.0 && conda clean -a
 ENV PATH /opt/conda/envs/bactopia/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image for Bactopia"
 

--- a/Singularity
+++ b/Singularity
@@ -11,5 +11,5 @@ From: nfcore/base
     export PATH
 
 %post
-    /opt/conda/bin/conda create -n bactopia -c conda-forge -c bioconda bactopia
+    /opt/conda/bin/conda create -n bactopia -c conda-forge -c bioconda bactopia=1.2.0
     /opt/conda/bin/conda clean -a

--- a/bactopia
+++ b/bactopia
@@ -35,6 +35,8 @@ if [[ $# == 0 ]]; then
     echo ""
     echo "\`bactopia pull\` - Pull (via Nextflow) the bactopia-ap GitHub repo"
     echo ""
+    echo "\`bactopia build\` - Build Bactopia Conda environments"
+    echo ""
     echo "\`bactopia datasets\` - Download/setup useful datasets for Bactopia"
     echo ""
     echo "\`bactopia prepare\` - Create a 'file of filenames' for input FASTQ files"
@@ -51,6 +53,8 @@ if [[ $# == 0 ]]; then
     echo ""
     echo "Example Commands"
     echo "bactopia --R1 SAMPLE_R1.fastq.gz --R2 SAMPLE_R2.fastq.gz --sample SAMPLE"
+    echo ""
+    echo "bactopia build /path/to/bactopia/conda-yml /path/to/install/conda/environments"
     echo ""
     echo "bactopia datasets dataset-dir --species 'Staphylococcus aureus'"
     echo "bactopia --dataset dataset-dir --species 'staphylococcus-aureus' --accession SRX4563671"
@@ -84,26 +88,27 @@ elif [[ "$1" == "version" ]] || [[ "$1" == "--version" ]]; then
 else
     # Check if Conda environments need to be built
     BUILD_CONDA=1
-    CHECKS=("condadir" "docker" "singularity" "slurm")
+    CHECKS=("condadir" "docker" "singularity" "slurm" "help" "help_all")
     for check in  "${CHECKS[@]}"; do
         if [[ "$*" == *"${check}"* ]]; then
             BUILD_CONDA=0
         fi
             TMP=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
-    fi
+    done
 
     if [[ "${BUILD_CONDA}" -eq 1 ]]; then
         # Figure out where Bactopia is setup
         TMPDIR=".bactopia."$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
         mkdir ${TMPDIR}
-        NF_DIR=$(cd ${TMPDIR} && nextflow run bactopia/bactopia --nfdir | grep "BACTOPIA_DIR" | cut -f 3 -d " " && cd ..)
+        NF_DIR=$(cd $TMPDIR && sh -c 'nextflow run /data/apps/bactopia/main.nf --nfdir | grep "BACTOPIA_DIR" | cut -f 3 -d " "' && cd ..)
         rm -rf ${TMPDIR}
-
-        if [[ ! -f "${NF_DIR}/conda/envs/envs-built.txt" ]]; then
-            build-conda-envs.py ${NF_DIR}/conda ${NF_DIR}/conda/envs
+        if [[ ! -f "${NF_DIR}/conda/envs/envs-built-${VERSION}.txt" ]]; then
+            echo "Unable to locate required Conda environments."
+            echo "Building to ${NF_DIR}/conda/envs ... This might take a while"
+            build-conda-envs.py ${NF_DIR}/conda ${NF_DIR}/conda/envs --force
         fi
     fi
 
     # Execute Bactopia Nextflow pipeline
-    nextflow run bactopia/bactopia "${@:1}"
+    nextflow run /data/apps/bactopia/main.nf "${@:1}"
 fi

--- a/bactopia
+++ b/bactopia
@@ -76,9 +76,34 @@ elif [[ "$1" == "prepare" ]]; then
 elif [[ "$1" == "search" ]]; then
     # Run ena-search
     ena-search.py "${@:2}"
+elif [[ "$1" == "build" ]]; then
+    # Run build-conda-envs
+    build-conda-envs.py "${@:2}"
 elif [[ "$1" == "version" ]] || [[ "$1" == "--version" ]]; then
     echo "bactopia ${VERSION}"
 else
+    # Check if Conda environments need to be built
+    BUILD_CONDA=1
+    CHECKS=("condadir" "docker" "singularity" "slurm")
+    for check in  "${CHECKS[@]}"; do
+        if [[ "$*" == *"${check}"* ]]; then
+            BUILD_CONDA=0
+        fi
+            TMP=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+    fi
+
+    if [[ "${BUILD_CONDA}" -eq 1 ]]; then
+        # Figure out where Bactopia is setup
+        TMPDIR=".bactopia."$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+        mkdir ${TMPDIR}
+        NF_DIR=$(cd ${TMPDIR} && nextflow run bactopia/bactopia --nfdir | grep "BACTOPIA_DIR" | cut -f 3 -d " " && cd ..)
+        rm -rf ${TMPDIR}
+
+        if [[ ! -f "${NF_DIR}/conda/envs/envs-built.txt" ]]; then
+            build-conda-envs.py ${NF_DIR}/conda ${NF_DIR}/conda/envs
+        fi
+    fi
+
     # Execute Bactopia Nextflow pipeline
     nextflow run bactopia/bactopia "${@:1}"
 fi

--- a/bactopia
+++ b/bactopia
@@ -24,7 +24,7 @@
 # bactopia fofn --help
 # bactopia version
 # bactopia --help
-VERSION=1.2.0
+VERSION=1.2.1
 
 # If no user input, print usage
 if [[ $# == 0 ]]; then

--- a/bactopia
+++ b/bactopia
@@ -100,7 +100,7 @@ else
         # Figure out where Bactopia is setup
         TMPDIR=".bactopia."$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
         mkdir ${TMPDIR}
-        NF_DIR=$(cd $TMPDIR && sh -c 'nextflow run /data/apps/bactopia/main.nf --nfdir | grep "BACTOPIA_DIR" | cut -f 3 -d " "' && cd ..)
+        NF_DIR=$(cd $TMPDIR && sh -c 'nextflow run bactopia/bactopia --nfdir | grep "BACTOPIA_DIR" | cut -f 3 -d " "' && cd ..)
         rm -rf ${TMPDIR}
         if [[ ! -f "${NF_DIR}/conda/envs/envs-built-${VERSION}.txt" ]]; then
             echo "Unable to locate required Conda environments."
@@ -110,5 +110,5 @@ else
     fi
 
     # Execute Bactopia Nextflow pipeline
-    nextflow run /data/apps/bactopia/main.nf "${@:1}"
+    nextflow run bactopia/bactopia "${@:1}"
 fi

--- a/bin/helpers/build-conda-envs.py
+++ b/bin/helpers/build-conda-envs.py
@@ -21,7 +21,7 @@ optional arguments:
 import logging
 import os
 
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 PROGRAM = "bactopia build"
 STDOUT = 11
 STDERR = 12

--- a/bin/helpers/build-conda-envs.py
+++ b/bin/helpers/build-conda-envs.py
@@ -1,0 +1,118 @@
+#! /usr/bin/env python3
+"""
+usage: bactopia build [-h] [-e STR] [--force] [--verbose] [--silent]
+                      [--version]
+                      STR STR
+
+bactopia build - Build Conda environments for use by Bactopia
+
+positional arguments:
+  STR                Directory containing Conda environment files to build.
+  STR                Directory to install Conda environments to.
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -e STR, --ext STR  Extension of the Conda environment files. Default: .yml
+  --force            Force overwrite of existing Conda environments.
+  --verbose          Print debug related text.
+  --silent           Only critical errors will be printed.
+  --version          show program's version number and exit
+"""
+import logging
+import os
+
+VERSION = "1.2.0"
+PROGRAM = "bactopia build"
+STDOUT = 11
+STDERR = 12
+logging.addLevelName(STDOUT, "STDOUT")
+logging.addLevelName(STDERR, "STDERR")
+
+
+def set_log_level(error, debug):
+    """Set the output log level."""
+    return logging.ERROR if error else logging.DEBUG if debug else logging.INFO
+
+
+def get_log_level():
+    """Return logging level name."""
+    return logging.getLevelName(logging.getLogger().getEffectiveLevel())
+
+
+def execute(cmd, directory=os.getcwd(), capture=False, stdout_file=None,
+            stderr_file=None):
+    """A simple wrapper around executor."""
+    from executor import ExternalCommand
+    command = ExternalCommand(
+        cmd, directory=directory, capture=True, capture_stderr=True,
+        stdout_file=stdout_file, stderr_file=stderr_file
+    )
+
+    command.start()
+    if get_log_level() == 'DEBUG':
+        logging.log(STDOUT, command.decoded_stdout)
+        logging.log(STDERR, command.decoded_stderr)
+
+    if capture:
+        return command.decoded_stdout
+
+if __name__ == '__main__':
+    import argparse as ap
+    import glob
+    import sys
+
+    parser = ap.ArgumentParser(
+        prog='bactopia build',
+        conflict_handler='resolve',
+        description=(
+            f'{PROGRAM} (v{VERSION}) - Build Conda environments for use by Bactopia'
+        )
+    )
+
+    parser.add_argument('conda_envs', metavar="STR", type=str,
+                        help='Directory containing Conda environment files to build.')
+
+    parser.add_argument('install_path', metavar="STR", type=str,
+                        help='Directory to install Conda environments to.')
+    parser.add_argument(
+        '-e', '--ext', metavar='STR', type=str,
+        default=".yml",
+        help='Extension of the Conda environment files. Default: .yml'
+    )
+    parser.add_argument('--force', action='store_true',
+                        help='Force overwrite of existing Conda environments.')
+    parser.add_argument('--verbose', action='store_true',
+                        help='Print debug related text.')
+    parser.add_argument('--silent', action='store_true',
+                        help='Only critical errors will be printed.')
+    parser.add_argument('--version', action='version',
+                        version=f'{PROGRAM} {VERSION}')
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args()
+
+    # Setup logs
+    FORMAT = '%(asctime)s:%(name)s:%(levelname)s - %(message)s'
+    logging.basicConfig(format=FORMAT, datefmt='%Y-%m-%d %H:%M:%S',)
+    logging.getLogger().setLevel(set_log_level(args.silent, args.verbose))
+
+    # https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob
+    env_path = os.path.abspath(args.conda_envs)
+    install_path = os.path.abspath(args.install_path)
+    finish_file = f'{install_path}/envs-build-{VERSION}.txt'
+    if not args.force and os.path.exists(finish_file):
+        logging.error(
+            f'Conda envs are already built in {install_path}, will not rebuild without --force'
+        )
+        sys.exit(1)
+
+    for env_file in glob.glob(f'{env_path}/*{args.ext}'):
+        envname = os.path.splitext(os.path.basename(env_file))[0]
+        prefix = f'{install_path}/{envname}-{VERSION}'
+        logging.info(f'Found {env_file}, begin build to {prefix}')
+        force = '--force' if args.force else ''
+        execute(f'conda env create -f {env_file} --prefix {prefix} {force}')
+    execute(f'touch {install_path}/envs-build-{VERSION}.txt')

--- a/bin/helpers/build-conda-envs.py
+++ b/bin/helpers/build-conda-envs.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
                         help='Directory to install Conda environments to.')
     parser.add_argument(
         '-e', '--ext', metavar='STR', type=str,
-        default=".yml",
+        default="yml",
         help='Extension of the Conda environment files. Default: .yml'
     )
     parser.add_argument('--force', action='store_true',
@@ -109,10 +109,17 @@ if __name__ == '__main__':
         )
         sys.exit(1)
 
-    for env_file in glob.glob(f'{env_path}/*{args.ext}'):
-        envname = os.path.splitext(os.path.basename(env_file))[0]
-        prefix = f'{install_path}/{envname}-{VERSION}'
-        logging.info(f'Found {env_file}, begin build to {prefix}')
-        force = '--force' if args.force else ''
-        execute(f'conda env create -f {env_file} --prefix {prefix} {force}')
-    execute(f'touch {install_path}/envs-build-{VERSION}.txt')
+    env_files = sorted(glob.glob(f'{env_path}/*.{args.ext}'))
+    if env_files:
+        for i, env_file in enumerate(env_files):
+            envname = os.path.splitext(os.path.basename(env_file))[0]
+            prefix = f'{install_path}/{envname}-{VERSION}'
+            logging.info(f'Found {env_file} ({i+1} or {len(env_files)}), begin build to {prefix}')
+            force = '--force' if args.force else ''
+            execute(f'conda env create -f {env_file} --prefix {prefix} {force}')
+        execute(f'touch {install_path}/envs-build-{VERSION}.txt')
+    else:
+        logging.error(
+            f'Unable to find Conda *.{args.ext} files in {env_path}, please verify'
+        )
+        sys.exit(1)

--- a/bin/helpers/build-conda-envs.py
+++ b/bin/helpers/build-conda-envs.py
@@ -117,7 +117,7 @@ if __name__ == '__main__':
             logging.info(f'Found {env_file} ({i+1} or {len(env_files)}), begin build to {prefix}')
             force = '--force' if args.force else ''
             execute(f'conda env create -f {env_file} --prefix {prefix} {force}')
-        execute(f'touch {install_path}/envs-build-{VERSION}.txt')
+        execute(f'touch {install_path}/envs-built-{VERSION}.txt')
     else:
         logging.error(
             f'Unable to find Conda *.{args.ext} files in {env_path}, please verify'

--- a/bin/helpers/ena-search.py
+++ b/bin/helpers/ena-search.py
@@ -28,7 +28,7 @@ example usage:
 
 """
 import sys
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 PROGRAM = "bactopia search"
 ENA_URL = ('https://www.ebi.ac.uk/ena/data/warehouse/search?result=read_run&'
            'display=report')

--- a/bin/helpers/prepare-fofn.py
+++ b/bin/helpers/prepare-fofn.py
@@ -1,6 +1,19 @@
 #! /usr/bin/env python3
 """
-Read a directory and prepare a FOFN of FASTQs
+usage: bactopia prepare [-h] [-e STR] [-s STR] [--pattern STR] [--version] STR
+
+bactopia prepare - Read a directory and prepare a FOFN of FASTQs
+
+positional arguments:
+  STR                Directory where FASTQ files are stored
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -e STR, --ext STR  Extension of the FASTQs. Default: .fastq.gz
+  -s STR, --sep STR  Split FASTQ name on the last occurrence of the separator.
+                     Default: _
+  --pattern STR      Glob pattern to match FASTQs. Default: *.fastq.gz
+  --version          show program's version number and exit
 """
 VERSION = "1.2.0"
 PROGRAM = "bactopia prepare"

--- a/bin/helpers/prepare-fofn.py
+++ b/bin/helpers/prepare-fofn.py
@@ -15,7 +15,7 @@ optional arguments:
   --pattern STR      Glob pattern to match FASTQs. Default: *.fastq.gz
   --version          show program's version number and exit
 """
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 PROGRAM = "bactopia prepare"
 
 if __name__ == '__main__':

--- a/bin/helpers/setup-datasets.py
+++ b/bin/helpers/setup-datasets.py
@@ -78,7 +78,7 @@ from Bio import SeqIO
 from executor import ExternalCommand
 
 PROGRAM = "bactopia datasets"
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 STDOUT = 11
 STDERR = 12
 CACHE_DIR = f'{os.path.expanduser("~")}/.bactopia'

--- a/bin/mask-consensus.py
+++ b/bin/mask-consensus.py
@@ -18,7 +18,7 @@ optional arguments:
   --version     show program's version number and exit
 """
 PROGRAM = "mask-consensus"
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 import sys
 
 

--- a/bin/mlst-blast.py
+++ b/bin/mlst-blast.py
@@ -17,7 +17,7 @@ optional arguments:
   --compressed  Input FASTA is Gzipped.
 """
 PROGRAM = "mlst-blast"
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 
 def pipe_command(cmd_1, cmd_2, stdout=False, stderr=False, verbose=True,
                  shell=False):

--- a/bin/select-references.py
+++ b/bin/select-references.py
@@ -2,7 +2,7 @@
 """
 """
 PROGRAM = "select-references"
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 
 if __name__ == '__main__':
     import argparse as ap

--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -12,7 +12,6 @@ if [[ $# == 0 ]]; then
     exit
 fi
 
-
 DIRECTORY=$1
 OLD_VERSION=$2
 NEW_VERSION=$3
@@ -39,6 +38,7 @@ if [ $? -eq 0 ]; then
         ${SED_CMD} -r 's=version: '"${OLD_VERSION}"'$=version: '"${NEW_VERSION}"'=' ${file}
     done
     ${SED_CMD} 's/VERSION='"${OLD_VERSION}"'/VERSION='"${NEW_VERSION}"'/' ${DIRECTORY}/conda/README.md
+    ${SED_CMD} -r 's=conda(.*)-'"${OLD_VERSION}"'=conda\1-'"${NEW_VERSION}"'=' ${DIRECTORY}/conf/conda.config
 
     # Python Scripts
     for file in $(ls ${DIRECTORY}/bin/*.py); do
@@ -48,7 +48,6 @@ if [ $? -eq 0 ]; then
     for file in $(ls ${DIRECTORY}/bin/helpers/*.py); do
         ${SED_CMD} -r 's/VERSION = "'"${OLD_VERSION}"'"/VERSION = "'"${NEW_VERSION}"'"/' ${file}
     done
-
 
     # Docker/Singularity
     ${SED_CMD} -r 's/version="'"${OLD_VERSION}"'"/version="'"${NEW_VERSION}"'"/' ${DIRECTORY}/Dockerfile

--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -12,6 +12,7 @@ if [[ $# == 0 ]]; then
     exit
 fi
 
+
 DIRECTORY=$1
 OLD_VERSION=$2
 NEW_VERSION=$3
@@ -38,7 +39,6 @@ if [ $? -eq 0 ]; then
         ${SED_CMD} -r 's=version: '"${OLD_VERSION}"'$=version: '"${NEW_VERSION}"'=' ${file}
     done
     ${SED_CMD} 's/VERSION='"${OLD_VERSION}"'/VERSION='"${NEW_VERSION}"'/' ${DIRECTORY}/conda/README.md
-    ${SED_CMD} -r 's=conda(.*)-'"${OLD_VERSION}"'=conda\1-'"${NEW_VERSION}"'=' ${DIRECTORY}/conf/conda.config
 
     # Python Scripts
     for file in $(ls ${DIRECTORY}/bin/*.py); do
@@ -54,20 +54,13 @@ if [ $? -eq 0 ]; then
     for file in $(ls ${DIRECTORY}/containers/docker/*.Dockerfile); do
         ${SED_CMD} -r 's/version="'"${OLD_VERSION}"'"/version="'"${NEW_VERSION}"'"/' ${file}
     done
-    ${SED_CMD} -r 's=container(.*):'"${OLD_VERSION}"'=container\1:'"${NEW_VERSION}"'=' ${DIRECTORY}/conf/docker.config
-
     for file in $(ls ${DIRECTORY}/containers/singularity/*.Singularity); do
         ${SED_CMD} -r 's/VERSION '"${OLD_VERSION}"'/VERSION '"${NEW_VERSION}"'/' ${file}
     done
-    ${SED_CMD} -r 's=container(.*):'"${OLD_VERSION}"'=container\1:'"${NEW_VERSION}"'=' ${DIRECTORY}/conf/singularity.config
-
-    # SLURM config
-    ${SED_CMD} -r 's/containerVersion = "'"${OLD_VERSION}"'"/containerVersion = "'"${NEW_VERSION}"'"/' ${DIRECTORY}/conf/slurm.config
 
     # Bactopia/Nextflow
     ${SED_CMD} 's/VERSION='"${OLD_VERSION}"'/VERSION='"${NEW_VERSION}"'/' ${DIRECTORY}/bactopia
     ${SED_CMD} -r "s/version = '${OLD_VERSION}'/version = '${NEW_VERSION}'/" ${DIRECTORY}/nextflow.config
-    ${SED_CMD} "s/VERSION = '${OLD_VERSION}'/VERSION = '${NEW_VERSION}'/" ${DIRECTORY}/main.nf
 else
     echo "Unable to execute '${DIRECTORY}/bactopia"
     echo "Please verify '${DIRECTORY}' points to the bactopia repo."

--- a/conda/README.md
+++ b/conda/README.md
@@ -2,7 +2,7 @@
 Below is a list of the commands used to create each enviroment.
 
 ```
-VERSION=1.2.0
+VERSION=1.2.1
 
 # annotate_genome.yml
 conda create -y -n bactopia-annotate_genome -c conda-forge -c bioconda prokka pigz

--- a/conda/annotate_genome.yml
+++ b/conda/annotate_genome.yml
@@ -1,5 +1,5 @@
 name: bactopia-annotate_genome
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/antimicrobial_resistance.yml
+++ b/conda/antimicrobial_resistance.yml
@@ -1,5 +1,5 @@
 name: bactopia-antimicrobial_resistance
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/ariba_analysis.yml
+++ b/conda/ariba_analysis.yml
@@ -1,5 +1,5 @@
 name: bactopia-ariba_analysis
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/assemble_genome.yml
+++ b/conda/assemble_genome.yml
@@ -1,5 +1,5 @@
 name: bactopia-assemble_genome
-version: 1.2.0
+version: 1.2.1
 channels:
   - rpetit3
   - conda-forge

--- a/conda/call_variants.yml
+++ b/conda/call_variants.yml
@@ -1,5 +1,5 @@
 name: bactopia-call_variants
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/count_31mers.yml
+++ b/conda/count_31mers.yml
@@ -1,5 +1,5 @@
 name: bactopia-count_31mers
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/download_references.yml
+++ b/conda/download_references.yml
@@ -1,5 +1,5 @@
 name: bactopia-download_references
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/gather_fastqs.yml
+++ b/conda/gather_fastqs.yml
@@ -1,5 +1,5 @@
 name: bactopia-gather_fastqs
-version: 1.2.0
+version: 1.2.1
 channels:
   - bioconda
   - rpetit3

--- a/conda/insertion_sequences.yml
+++ b/conda/insertion_sequences.yml
@@ -1,5 +1,5 @@
 name: bactopia-insertion_sequences
-version: 1.2.0
+version: 1.2.1
 channels:
   - rpetit3
   - conda-forge

--- a/conda/minmers.yml
+++ b/conda/minmers.yml
@@ -1,5 +1,5 @@
 name: bactopia-minmers
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/qc_reads.yml
+++ b/conda/qc_reads.yml
@@ -1,5 +1,5 @@
 name: bactopia-qc_reads
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conda/sequence_type.yml
+++ b/conda/sequence_type.yml
@@ -1,5 +1,5 @@
 name: bactopia-sequence_type
-version: 1.2.0
+version: 1.2.1
 channels:
   - conda-forge
   - bioconda

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -2,6 +2,7 @@ executor {
     name = 'awsbatch'
     awscli = '/home/ec2-user/miniconda/bin/aws'
 }
+
 process {
     executor = 'awsbatch'
     queue = 'nextflow-large'

--- a/conf/base.config
+++ b/conf/base.config
@@ -1,0 +1,80 @@
+process {
+    // Defaults
+    cpus = {check_max(1, 'cpus' )}
+    memory = {check_max(1.GB * task.attempt, 'memory' )}
+    time = {check_max( 30.m * task.attempt, 'time' )}
+    errorStrategy = 'retry'
+    maxRetries = 1
+
+    // Full cpus
+    withName: 'annotate_genome|antimicrobial_resistance|blast_query|mapping_query' {
+        cpus = {check_max(params.cpus, 'cpus')}
+    }
+
+    // Half cpus
+    withName: 'insertion_sequences|qc_original_summary|qc_final_summary' {
+        cpus = {check_max(Math.round(params.cpus * 0.5), 'cpus' )}
+    }
+
+    withName: plasmid_blast {
+        cpus = {check_max(params.cpus, 'cpus' )}
+        memory = 3.GB
+    }
+
+    withName: ariba_analysis {
+        cpus = {task.attempt > 1 ? 1 : Math.round(params.cpus * 0.75)}
+        maxRetries = 1
+        memory = 2.GB
+        validExitStatus = [0,1]
+    }
+
+    withName: qc_reads {
+        cpus = {check_max( params.cpus, 'cpus' )}
+        maxRetries = Math.round(params.max_memory / params.qc_ram)
+        memory = {check_max(((params.qc_ram).GB * task.attempt), 'memory')}
+    }
+
+    withName: assemble_genome {
+        cpus = {check_max(Math.round(params.cpus * 0.75), 'cpus' )}
+        memory = {check_max(((params.shovill_ram).GB * task.attempt), 'memory')}
+        maxRetries = Math.round(params.max_memory / params.shovill_ram)
+    }
+
+    withName: 'call_variants|call_variants_auto' {
+        cpus = Math.round(params.cpus * 0.75)
+        errorStrategy = 'retry'
+        maxRetries = 3
+        memory = {check_max(((params.snippy_ram).GB * task.attempt), 'memory')}
+    }
+
+    withName: count_31mers {
+        cpus = {check_max(params.cpus, 'cpus' )}
+        errorStrategy = 'retry'
+        maxRetries = Math.round(params.max_memory / params.cortex_ram)
+        memory = {check_max(((params.cortex_ram).GB * task.attempt), 'memory')}
+    }
+
+    withName: minmer_query {
+        cpus = {check_max( params.cpus, 'cpus' )}
+        errorStrategy = 'retry'
+        maxRetries = Math.round(params.max_memory / params.minmer_ram)
+        memory = {check_max(((params.minmer_ram).GB * task.attempt), 'memory')}
+    }
+
+    withName: download_references {
+        errorStrategy = 'retry'
+        maxRetries = 6
+        validExitStatus = [0,75]
+    }
+
+    withName: 'gather_fastqs' {
+        errorStrategy = 'retry'
+        maxForks = 1
+        maxRetries = 20
+    }
+
+    withName: sequence_type {
+        errorStrategy = 'retry'
+        maxRetries = 5
+    }
+}

--- a/conf/conda.config
+++ b/conf/conda.config
@@ -1,0 +1,38 @@
+process {
+    withName: 'annotate_genome|make_blastdb|blast_query|plasmid_blast' {
+        conda = "${params.condadir}/annotate_genome-${manifest.version}"
+    }
+    withName: 'update_antimicrobial_resistance|antimicrobial_resistance' {
+        conda = "${params.condadir}/antimicrobial_resistance-${manifest.version}"
+    }
+    withName: ariba_analysis {
+        conda = "${params.condadir}/ariba_analysis-${manifest.version}"
+    }
+    withName: assemble_genome {
+        conda = "${params.condadir}/assemble_genome-${manifest.version}"
+    }
+    withName: 'call_variants|call_variants_auto|mapping_query' {
+        conda = "${params.condadir}/call_variants-${manifest.version}"
+    }
+    withName: count_31mers {
+        conda = "${params.condadir}/count_31mers-${manifest.version}"
+    }
+    withName: download_references {
+        conda = "${params.condadir}/download_references-${manifest.version}"
+    }
+    withName: 'estimate_genome_size|minmer_sketch|minmer_query' {
+        conda = "${params.condadir}/minmers-${manifest.version}"
+    }
+    withName: 'gather_fastqs' {
+        conda = "${params.condadir}/gather_fastqs-${manifest.version}"
+    }
+    withName: insertion_sequences {
+        conda = "${params.condadir}/insertion_sequences-${manifest.version}"
+    }
+    withName: 'fastq_status|qc_reads|qc_original_summary|qc_final_summary' {
+        conda = "${params.condadir}/qc_reads-${manifest.version}"
+    }
+    withName: sequence_type {
+        conda = "${params.condadir}/sequence_type-${manifest.version}"
+    }
+}

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -1,39 +1,39 @@
 process {
     withName: 'annotate_genome|make_blastdb|blast_query|plasmid_blast' {
-        container = "bactopia/annotate_genome:1.2.0"
+        container = "bactopia/annotate_genome:${manifest.version}"
     }
     withName: 'update_antimicrobial_resistance|antimicrobial_resistance' {
-        container = "bactopia/antimicrobial_resistance:1.2.0"
+        container = "bactopia/antimicrobial_resistance:${manifest.version}"
     }
     withName: ariba_analysis {
-        container = "bactopia/ariba_analysis:1.2.0"
+        container = "bactopia/ariba_analysis:${manifest.version}"
     }
     withName: assemble_genome {
-        container = "bactopia/assemble_genome:1.2.0"
+        container = "bactopia/assemble_genome:${manifest.version}"
     }
     withName: 'call_variants|call_variants_auto|mapping_query' {
-        container = "bactopia/call_variants:1.2.0"
+        container = "bactopia/call_variants:${manifest.version}"
     }
     withName: count_31mers {
-        container = "bactopia/count_31mers:1.2.0"
+        container = "bactopia/count_31mers:${manifest.version}"
     }
     withName: download_references {
-        container = "bactopia/download_references:1.2.0"
+        container = "bactopia/download_references:${manifest.version}"
     }
     withName: 'estimate_genome_size|minmer_sketch|minmer_query' {
-        container = "bactopia/minmers:1.2.0"
+        container = "bactopia/minmers:${manifest.version}"
     }
     withName: 'gather_fastqs' {
-        container = "bactopia/gather_fastqs:1.2.0"
+        container = "bactopia/gather_fastqs:${manifest.version}"
     }
     withName: insertion_sequences {
-        container = "bactopia/insertion_sequences:1.2.0"
+        container = "bactopia/insertion_sequences:${manifest.version}"
     }
     withName: 'fastq_status|qc_reads|qc_original_summary|qc_final_summary' {
-        container = "bactopia/qc_reads:1.2.0"
+        container = "bactopia/qc_reads:${manifest.version}"
     }
     withName: sequence_type {
-        container = "bactopia/sequence_type:1.2.0"
+        container = "bactopia/sequence_type:${manifest.version}"
     }
 }
 docker.enabled = true

--- a/conf/params.config
+++ b/conf/params.config
@@ -5,9 +5,10 @@ This file includes default values for all Bactopia parameters.
 params {
     // Bactopia
     genome_size = null
+    max_time = 120
     max_memory = 32
-    max_cpus = 1
-    cpus = 1
+    max_cpus = 16
+    cpus = 4
     outdir = '.'
     fastqs = null
     R1 = null
@@ -16,7 +17,7 @@ params {
     accessions = null
     accession = null
     sample = null
-    dataset = null
+    datasets = null
     species = null
     available_datasets = null
     example_fastqs = null
@@ -27,6 +28,9 @@ params {
     help_all = null
     version = null
     dry_run = false
+    infodir = "${params.outdir}/bactopia-info"
+    condadir = "${baseDir}/conda/envs"
+    nfdir = false
 
     // process gather_fastqs
     aspera_speed = "100M"
@@ -75,9 +79,10 @@ params {
     maxcor = 1
     sampleseed = 42
     skip_error_correction = false
+    qc_ram = 3
 
     // process assemble_genome
-    shovill_ram = 16
+    shovill_ram = 6
     assembler = 'skesa'
     min_contig_len = 500
     min_contig_cov = 2
@@ -111,6 +116,7 @@ params {
     // process minmer_query
     screen_w = true
     screen_i = 0.8
+    minmer_ram = 5
 
     // process ariba_analysis
     nucmer_min_id = 90
@@ -125,7 +131,7 @@ params {
     ariba_no_clean = false
 
     // process call_variants
-    snippy_ram = 16
+    snippy_ram = 4
     mapqual = 60
     basequal = 13
     mincov = 10

--- a/conf/params.config
+++ b/conf/params.config
@@ -7,7 +7,6 @@ params {
     genome_size = null
     max_time = 120
     max_memory = 32
-    max_cpus = 16
     cpus = 4
     outdir = '.'
     fastqs = null

--- a/conf/profiles.config
+++ b/conf/profiles.config
@@ -1,46 +1,6 @@
-/*
-
-*/
 profiles {
     standard {
-        process {
-            withName: 'annotate_genome|make_blastdb|blast_query|plasmid_blast' {
-                conda = "${baseDir}/conda/annotate_genome.yml"
-            }
-            withName: 'update_antimicrobial_resistance|antimicrobial_resistance' {
-                conda = "${baseDir}/conda/antimicrobial_resistance.yml"
-            }
-            withName: ariba_analysis {
-                conda = "${baseDir}/conda/ariba_analysis.yml"
-            }
-            withName: assemble_genome {
-                conda = "${baseDir}/conda/assemble_genome.yml"
-            }
-            withName: 'call_variants|call_variants_auto|mapping_query' {
-                conda = "${baseDir}/conda/call_variants.yml"
-            }
-            withName: count_31mers {
-                conda = "${baseDir}/conda/count_31mers.yml"
-            }
-            withName: download_references {
-                conda = "${baseDir}/conda/download_references.yml"
-            }
-            withName: 'estimate_genome_size|minmer_sketch|minmer_query' {
-                conda = "${baseDir}/conda/minmers.yml"
-            }
-            withName: 'gather_fastqs' {
-                conda = "${baseDir}/conda/gather_fastqs.yml"
-            }
-            withName: insertion_sequences {
-                conda = "${baseDir}/conda/insertion_sequences.yml"
-            }
-            withName: 'fastq_status|qc_reads|qc_original_summary|qc_final_summary' {
-                conda = "${baseDir}/conda/qc_reads.yml"
-            }
-            withName: sequence_type {
-                conda = "${baseDir}/conda/sequence_type.yml"
-            }
-        }
+        includeConfig "${baseDir}/conf/conda.config"
     }
 
     docker {

--- a/conf/singularity-path.config
+++ b/conf/singularity-path.config
@@ -3,39 +3,39 @@ singularity.autoMounts = true
 
 process {
     withName: 'annotate_genome|make_blastdb|blast_query|plasmid_blast' {
-        container = "${params.containerPath}/annotate_genome-${params.containerVersion}.simg"
+        container = "${params.containerPath}/annotate_genome-${manifest.version}.simg"
     }
     withName: 'update_antimicrobial_resistance|antimicrobial_resistance' {
-        container = "${params.containerPath}/antimicrobial_resistance-${params.containerVersion}.simg"
+        container = "${params.containerPath}/antimicrobial_resistance-${manifest.version}.simg"
     }
     withName: ariba_analysis {
-        container = "${params.containerPath}/ariba_analysis-${params.containerVersion}.simg"
+        container = "${params.containerPath}/ariba_analysis-${manifest.version}.simg"
     }
     withName: assemble_genome {
-        container = "${params.containerPath}/assemble_genome-${params.containerVersion}.simg"
+        container = "${params.containerPath}/assemble_genome-${manifest.version}.simg"
     }
     withName: 'call_variants|call_variants_auto|mapping_query' {
-        container = "${params.containerPath}/call_variants-${params.containerVersion}.simg"
+        container = "${params.containerPath}/call_variants-${manifest.version}.simg"
     }
     withName: count_31mers {
-        container = "${params.containerPath}/count_31mers-${params.containerVersion}.simg"
+        container = "${params.containerPath}/count_31mers-${manifest.version}.simg"
     }
     withName: download_references {
-        container = "${params.containerPath}/download_references-${params.containerVersion}.simg"
+        container = "${params.containerPath}/download_references-${manifest.version}.simg"
     }
     withName: 'estimate_genome_size|minmer_sketch|minmer_query' {
-        container = "${params.containerPath}/minmers-${params.containerVersion}.simg"
+        container = "${params.containerPath}/minmers-${manifest.version}.simg"
     }
     withName: 'gather_fastqs' {
-        container = "${params.containerPath}/gather_fastqs-${params.containerVersion}.simg"
+        container = "${params.containerPath}/gather_fastqs-${manifest.version}.simg"
     }
     withName: insertion_sequences {
-        container = "${params.containerPath}/insertion_sequences-${params.containerVersion}.simg"
+        container = "${params.containerPath}/insertion_sequences-${manifest.version}.simg"
     }
     withName: 'fastq_status|qc_reads|qc_original_summary|qc_final_summary' {
-        container = "${params.containerPath}/qc_reads-${params.containerVersion}.simg"
+        container = "${params.containerPath}/qc_reads-${manifest.version}.simg"
     }
     withName: sequence_type {
-        container = "${params.containerPath}/sequence_type-${params.containerVersion}.simg"
+        container = "${params.containerPath}/sequence_type-${manifest.version}.simg"
     }
 }

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -2,39 +2,39 @@ singularity.enabled = true
 
 process {
     withName: 'annotate_genome|make_blastdb|blast_query|plasmid_blast' {
-        container = "library://rpetit3/bactopia/annotate_genome:1.2.0"
+        container = "library://rpetit3/bactopia/annotate_genome:${manifest.version}"
     }
     withName: 'update_antimicrobial_resistance|antimicrobial_resistance' {
-        container = "library://rpetit3/bactopia/antimicrobial_resistance:1.2.0"
+        container = "library://rpetit3/bactopia/antimicrobial_resistance:${manifest.version}"
     }
     withName: ariba_analysis {
-        container = "library://rpetit3/bactopia/ariba_analysis:1.2.0"
+        container = "library://rpetit3/bactopia/ariba_analysis:${manifest.version}"
     }
     withName: assemble_genome {
-        container = "library://rpetit3/bactopia/assemble_genome:1.2.0"
+        container = "library://rpetit3/bactopia/assemble_genome:${manifest.version}"
     }
     withName: 'call_variants|call_variants_auto|mapping_query' {
-        container = "library://rpetit3/bactopia/call_variants:1.2.0"
+        container = "library://rpetit3/bactopia/call_variants:${manifest.version}"
     }
     withName: count_31mers {
-        container = "library://rpetit3/bactopia/count_31mers:1.2.0"
+        container = "library://rpetit3/bactopia/count_31mers:${manifest.version}"
     }
     withName: download_references {
-        container = "library://rpetit3/bactopia/download_references:1.2.0"
+        container = "library://rpetit3/bactopia/download_references:${manifest.version}"
     }
     withName: 'estimate_genome_size|minmer_sketch|minmer_query' {
-        container = "library://rpetit3/bactopia/minmers:1.2.0"
+        container = "library://rpetit3/bactopia/minmers:${manifest.version}"
     }
     withName: 'gather_fastqs' {
-        container = "library://rpetit3/bactopia/gather_fastqs:1.2.0"
+        container = "library://rpetit3/bactopia/gather_fastqs:${manifest.version}"
     }
     withName: insertion_sequences {
-        container = "library://rpetit3/bactopia/insertion_sequences:1.2.0"
+        container = "library://rpetit3/bactopia/insertion_sequences:${manifest.version}"
     }
     withName: 'fastq_status|qc_reads|qc_original_summary|qc_final_summary' {
-        container = "library://rpetit3/bactopia/qc_reads:1.2.0"
+        container = "library://rpetit3/bactopia/qc_reads:${manifest.version}"
     }
     withName: sequence_type {
-        container = "library://rpetit3/bactopia/sequence_type:1.2.0"
+        container = "library://rpetit3/bactopia/sequence_type:${manifest.version}"
     }
 }

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -1,6 +1,5 @@
 params {
     containerPath = "/opt/bactopia/singularity"
-    containerVersion = "1.2.0"
 }
 
 process {

--- a/containers/docker/annotate_genome.Dockerfile
+++ b/containers/docker/annotate_genome.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia annotate_genome process"
 

--- a/containers/docker/antimicrobial_resistance.Dockerfile
+++ b/containers/docker/antimicrobial_resistance.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia antimicrobial_resistance process"
 

--- a/containers/docker/ariba_analysis.Dockerfile
+++ b/containers/docker/ariba_analysis.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia ariba_analysis process"
 

--- a/containers/docker/assemble_genome.Dockerfile
+++ b/containers/docker/assemble_genome.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia assemble_genome process"
 

--- a/containers/docker/call_variants.Dockerfile
+++ b/containers/docker/call_variants.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia call_variants process"
 

--- a/containers/docker/count_31mers.Dockerfile
+++ b/containers/docker/count_31mers.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia count_31mers process"
 

--- a/containers/docker/download_references.Dockerfile
+++ b/containers/docker/download_references.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia download_references process"
 

--- a/containers/docker/gather_fastqs.Dockerfile
+++ b/containers/docker/gather_fastqs.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia gather_fastqs process"
 

--- a/containers/docker/insertion_sequences.Dockerfile
+++ b/containers/docker/insertion_sequences.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia insertion_sequences process"
 

--- a/containers/docker/minmers.Dockerfile
+++ b/containers/docker/minmers.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia minmers process"
 

--- a/containers/docker/qc_reads.Dockerfile
+++ b/containers/docker/qc_reads.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia qc_reads process"
 

--- a/containers/docker/sequence_type.Dockerfile
+++ b/containers/docker/sequence_type.Dockerfile
@@ -1,7 +1,7 @@
 FROM nfcore/base
 MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
 
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 LABEL authors="robert.petit@emory.edu"
 LABEL description="Container image containing requirements for the Bactopia sequence_type process"
 

--- a/containers/singularity/annotate_genome.Singularity
+++ b/containers/singularity/annotate_genome.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia annotate_genome process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-annotate_genome/bin:$PATH

--- a/containers/singularity/antimicrobial_resistance.Singularity
+++ b/containers/singularity/antimicrobial_resistance.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia antimicrobial_resistance process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-antimicrobial_resistance/bin:$PATH

--- a/containers/singularity/ariba_analysis.Singularity
+++ b/containers/singularity/ariba_analysis.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia ariba_analysis process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-ariba_analysis/bin:$PATH

--- a/containers/singularity/assemble_genome.Singularity
+++ b/containers/singularity/assemble_genome.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia assemble_genome process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-assemble_genome/bin:$PATH

--- a/containers/singularity/call_variants.Singularity
+++ b/containers/singularity/call_variants.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia call_variants process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-call_variants/bin:$PATH

--- a/containers/singularity/count_31mers.Singularity
+++ b/containers/singularity/count_31mers.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia count_31mers process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-count_31mers/bin:$PATH

--- a/containers/singularity/download_references.Singularity
+++ b/containers/singularity/download_references.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia download_references process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-download_references/bin:$PATH

--- a/containers/singularity/gather_fastqs.Singularity
+++ b/containers/singularity/gather_fastqs.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia gather_fastqs process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-gather_fastqs/bin:$PATH

--- a/containers/singularity/insertion_sequences.Singularity
+++ b/containers/singularity/insertion_sequences.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia insertion_sequences process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-insertion_sequences/bin:$PATH

--- a/containers/singularity/minmers.Singularity
+++ b/containers/singularity/minmers.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia minmers process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-minmers/bin:$PATH

--- a/containers/singularity/qc_reads.Singularity
+++ b/containers/singularity/qc_reads.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia qc_reads process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-qc_reads/bin:$PATH

--- a/containers/singularity/sequence_type.Singularity
+++ b/containers/singularity/sequence_type.Singularity
@@ -4,7 +4,7 @@ From: nfcore/base
 %labels
     MAINTAINER Robert A. Petit III <robert.petit@emory.edu>
     DESCRIPTION Singularity image containing requirements for the Bactopia sequence_type process
-    VERSION 1.2.0
+    VERSION 1.2.1
 
 %environment
     PATH=/opt/conda/envs/bactopia-sequence_type/bin:$PATH

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -82,19 +82,19 @@ This will setup the MLST schema (if available) and a protein cluster FASTA file 
 
 ## Usage
 ``` 
-usage: setup-datasets [-h] [--ariba STR] [--species STR]
-                           [--skip_prokka] [--include_genus]
-                           [--identity FLOAT] [--overlap FLOAT]
-                           [--max_memory INT] [--fast_cluster]
-                           [--skip_minmer] [--skip_plsdb] [--cpus INT]
-                           [--clear_cache] [--force] [--force_ariba]
-                           [--force_mlst] [--force_prokka]
-                           [--force_minmer] [--force_plsdb]
-                           [--keep_files] [--list_datasets] [--depends]
-                           [--version] [--verbose] [--silent]
-                           OUTPUT_DIRECTORY
+usage: bactopia datasets [-h] [--ariba STR] [--species STR]
+                              [--skip_prokka] [--include_genus]
+                              [--identity FLOAT] [--overlap FLOAT]
+                              [--max_memory INT] [--fast_cluster]
+                              [--skip_minmer] [--skip_plsdb] [--cpus INT]
+                              [--clear_cache] [--force] [--force_ariba]
+                              [--force_mlst] [--force_prokka]
+                              [--force_minmer] [--force_plsdb]
+                              [--keep_files] [--list_datasets] [--depends]
+                              [--version] [--verbose] [--silent]
+                              OUTPUT_DIRECTORY
 
-setup-datasets - Setup public datasets for Bactopia
+bactopia datasets - Setup public datasets for Bactopia
 
 positional arguments:
   OUTPUT_DIRECTORY  Directory to write output.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,6 @@ conda activate bactopia
 
 And voilà, you are all set to get started processing your data!
 
-
 But first, it is highly recommended that you take the time to [Build Datasets](datasets.md) that Bactopia can take advantage of.
 
 ## Container

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -23,6 +23,8 @@ This will build the following datasets:
 More information about these datasets is available at [Build Datasets](/datasets/).
 
 ## Run Bactopia!
+On the first launch of Bactopia it will install the Conda environments, so expect some delays in doing so!
+
 ### Single Sample
 #### Paired-End
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,16 @@ It was bound to happen, an error has occurred or a bug has shown itself. Now let
 !!! error "Don't see your error/bug? Post an issue on GitHub"
     If you've encountered an error or bug not seen here, please post an issue at [Bactopia GitHub Issues](https://github.com/bactopia/bactopia/issues). This will help greatly to track down the error and fix it!
 
+## Past Errors
+
+!!! error "These should have been fixed."
+    The following errors should have been fixed. If you are still receiving them, please make sure you are using the most up to date version of Bactopia. If you are, and you are still recieving one of these errors, please reopen the associated issue on GitHub. Thanks!
+
 ### Failed to create Conda Environment
+
+!!! info "This was fixed in v1.2.1"
+    A new function `bactopia build` was introduced that builds the Conda environments outside of Nextflow. If you are still receiving this error please reopen the [Better handling of conda environments?](https://github.com/bactopia/bactopia/issues/13) issue.
+
 Occasionally on the first run of Bactopia you will encounter this error: 
 ```
 Caused by:
@@ -16,9 +25,3 @@ Caused by:
 ```
 
 While it may look like this is related to Nextflow, it is actually a Conda error that occurs when installing multiple environments at once which Nextflow likes to do. This can also occur from a timeout or loss of internet connectivity (under a different error name).
-
-**Recommended Solution**  
-Using `--dry_run` at runtime will run Bactopia with dummy data on a single core to prevent parallel creation of conda environments. This process will take only as long as it takes to create the environments.
-
-If you have suggestions for how to better handle this, check out the submitted [Better handling of conda environments?](https://github.com/bactopia/bactopia/issues/13) issue. Your feedback would be greatly appreciated!
-

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -45,7 +45,7 @@ Let's review what is happening here.
 
 `--include_genus` will also download completed genomes from the *Staphylococcus* genus that will be used for the protein set. These completed genomes **are not** used for the sketch creation or genome size calculation.
 
-`--cpus 4` use 4 cpus for downloading and the clustering step. Adjust this number according to your setup!
+`--cpus 4` will use 4 cpus for downloading and the clustering step. Adjust this number according to your setup!
 
 !!! info "Use CARD over MEGARes"
     Staphopia v1 made use of MEGARes, for the purposes of this tutorial we are going to use the CARD database instead.
@@ -83,11 +83,10 @@ Let's start this by downloading a single sample from ENA, and processing it thro
 
 ```
 bactopia --accession SRX4563634 \
-         --dataset datasets/ \
-         --species staphylococcus-aureus \
+         --datasets datasets/ \
+         --species "Staphylococcus aureus" \
          --coverage 100 \
          --genome_size median \
-         --max_cpus 8 \
          --cpus 2 \
          --outdir ena-single-sample
 ```
@@ -96,15 +95,15 @@ So, what's happening here?
 
 `--accession SRX4563634` is telling Bactopia to download FASTQs associated with Exeriment accession SRX4563634.
 
-`--dataset datasets/` tells Bactopia your pre-built datasets are in the folder `datasets`.
+`--datasets datasets/` tells Bactopia your pre-built datasets are in the folder `datasets`.
 
-`--species staphylococcus-aureus` tells Bactopia, within the datasets folder, use the species specific dataset for *S. aureus*.
+`--species "Staphylococcus aureus"` tells Bactopia, within the datasets folder, use the species specific dataset for *S. aureus*.
 
 `--coverage 100` will limit the cleaned up FASTQ file to an estimated 100x coverage based on the genome size.
 
 `--genome_size median` tells Bactopia to use the median genome size of completed *S. aureus* genomes. The minimum, maximum, median, and mean genome sizes were calculated during the dataset building step. If a genome size was not given, it would have been estimated by Mash.
 
-`--max_cpus 8` and `--cpus 2` tells Bactopia to use a maximum of 8 cpus (`--max_cpus`) and each job within the workflow can use a maximum of 2 cpus (`--cpus`). So at most 8 jobs (using 1 cpu each) can run at a time, and a minimum of 4 jobs (using 2 cpus each). Adjust these parameters to fit your setup!
+`--cpus 2` tells Bactopia to use a maximum of 2 cpus per process. Adjust this parameter to fit your setup!
 
 `--outdir ena-single-sample` tells Bactopia to dump the results into the `ena-single-sample` folder. Please keep in mind, this will not stop Nextflow from creating files (.nextflow, trace.txt, etc...) and directories (work and .nextflow/) within your current directory.
 
@@ -138,11 +137,10 @@ To process these samples, we will adjust our command used previously.
 
 ```
 bactopia --accessions ena-accessions.txt \
-         --dataset datasets/ \
-         --species staphylococcus-aureus \
+         --datasets datasets/ \
+         --species "Staphylococcus aureus" \
          --coverage 100 \
          --genome_size median \
-         --max_cpus 8 \
          --cpus 2 \
          --outdir ena-multiple-samples
 ```
@@ -183,11 +181,10 @@ For paired-end reads you will want to use `--R1`, `--R2`, and `--sample`. For th
 bactopia --R1 fastqs/SRX4563634_R1.fastq.gz \
          --R2 fastqs/SRX4563634_R2.fastq.gz \
          --sample SRX4563634 \
-         --dataset datasets/ \
-         --species staphylococcus-aureus \
+         --datasets datasets/ \
+         --species "Staphylococcus aureus" \
          --coverage 100 \
          --genome_size median \
-         --max_cpus 8 \
          --cpus 2 \
          --outdir local-single-sample
 ```
@@ -205,11 +202,10 @@ To analyze single-end reads, the `--SE` parameter will replace `--R1` and `--R2`
 ```
 bactopia --SE fastqs/SRX4563634-SE.fastq.gz \
          --sample SRX4563634-SE \
-         --dataset datasets/ \
-         --species staphylococcus-aureus \
+         --datasets datasets/ \
+         --species "Staphylococcus aureus" \
          --coverage 100 \
          --genome_size median \
-         --max_cpus 8 \
          --cpus 2 \
          --outdir local-single-sample
 ```
@@ -237,11 +233,10 @@ Now we can use the `--fastqs` parameters to process samples in the FOFN.
 
 ```
 bactopia --fastqs fastqs.txt \
-         --dataset datasets/ \
-         --species staphylococcus-aureus \
+         --datasets datasets/ \
+         --species "Staphylococcus aureus" \
          --coverage 100 \
          --genome_size median \
-         --max_cpus 8 \
          --cpus 2 \
          --outdir local-multiple-samples
 ```
@@ -254,7 +249,6 @@ Once this is complete, the results for each sample (within their own folder) wil
 
 !!! info "FOFN is more cpu efficient, making it faster"
     The real benefit of using the FOFN method to process multiple samples is Nextflow's queue system will make better use of cpus. Processing multiple samples one at a time (via `--R1`/`--R2` or `--SE`) will lead more instances of jobs waiting on other jobs to finish, during which cpus aren't being used.
-
 
 ## What's next?
 That should do it! Hopefully you have succeeded (yay! 🎉) and would like to use Bactopia on your own data! 

--- a/docs/usage-basic.md
+++ b/docs/usage-basic.md
@@ -49,19 +49,26 @@ Optional Parameters:
                                 Default: Mash estimate
 
     --outdir DIR            Directory to write results to
-                                Default .
+                                Default: .
+
+    --max_time INT          The maximum number of minutes a job should run before being halted.
+                                Default: 120 minutes
 
     --max_memory INT        The maximum amount of memory (Gb) allowed to a single process.
                                 Default: 32 Gb
 
-    --max_cpus INT          The maximum number of processors this workflow
-                                should have access to at any given moment
-                                Default: 1
-
     --cpus INT              Number of processors made available to a single
-                                process. If greater than "--max_cpus" it
-                                will be set equal to "--max_cpus"
-                                Default: 1
+                                process.
+                                Default: 4
+
+Nextflow Related Parameters:
+    --infodir DIR           Directory to write Nextflow summary files to
+                                Default: ./bactopia-info
+
+    --condadir DIR          Directory to Nextflow should use for Conda environments
+                                Default: Bactopia's Nextflow directory
+
+    --nfdir                 Print directory Nextflow has pulled Bactopia to
 
 Useful Parameters:
     --available_datasets    Print a list of available datasets found based
@@ -78,6 +85,10 @@ Useful Parameters:
                                 files are removed. This will not affect the ability
                                 to resume Nextflow runs, and only occurs at the end
                                 of the process.
+
+    --dry_run               Mimics workflow execution, to help prevent errors realated to
+                                conda envs being built in parallel. Only useful on new
+                                installs of Bactopia.
 
     --version               Print workflow version information
 
@@ -309,24 +320,6 @@ Throughout the Bactopia workflow a genome size is used for various tasks. By def
 
 !!! error "Mash may not be the most accurate estimate"
     Mash is very convenient to quickly estimate a genome size, but it may not be the most accurate in all cases and will differ between samples. It is recommended that when possible a known genome size or one based off completed genomes should be used. 
-
-## `--max_cpus` & `--cpus`
-When Nextflow executes, it uses all available cpus to queue up processes. As you might imagine, if you are on a single server with multiple users, this approach of using all cpus might annoy other users! (Whoops sorry!) To circumvent this feature, two parmeters have been included `--max_cpus` and `--cpus`.
-
-```
-    --max_cpus INT          The maximum number of processors this workflow
-                                should have access to at any given moment
-                                Default: 1
-
-    --cpus INT              Number of processors made available to a single
-                                process. If greater than "--max_cpus" it
-                                will be set equal to "--max_cpus"
-                                Default: 1
-```
-
-What `--max_cpus` does is specify to Nextflow the maximum number of cpus it is allowed to occupy at any given time. `--cpus` on the other hand, specifies how many cpus any given step (qc, assembly, annotation, etc...) can occupy. 
-
-By default `--max_cpus` is set to 1 and if `--cpus` is set to a value greater than `--max_cpus` it will be set equal to `--max_cpus`. This appoach errs on the side of caution, by not occupying all cpus on the server without the user's consent!
 
 ## `--keep_all_files`
 In some processes, Bactopia will delete large intermediate files (e.g. multiple uncompressed FASTQs) **only** after a process successfully completes. Since this a per-process function, it does not affect Nextflow's ability to resume (`-resume`)a workflow. You can deactivate this feature using `--keep_all_files`. Please, keep in mind the *work* directory is already large, this will make it 2-3 times larger.

--- a/docs/usage-complete.md
+++ b/docs/usage-complete.md
@@ -39,7 +39,7 @@ If you followed the steps in [Build Datasets](datasets.md), you can use the foll
 ```
 
 ## Optional
-These optional parameters, while not required, will be quite useful (especially `--max_cpus` and `--cpus`!) to tweak.
+These optional parameters, while not required, will be quite useful to tweak.
 
 ```
     --coverage INT          Reduce samples to a given coverage
@@ -55,10 +55,17 @@ These optional parameters, while not required, will be quite useful (especially 
                                 Default: Mash estimate
 
     --outdir DIR            Directory to write results to
-                                Default .
+                                Default: .
+
+    --max_time INT          The maximum number of minutes a job should run before being halted.
+                                Default: 120 minutes
 
     --max_memory INT        The maximum amount of memory (Gb) allowed to a single process.
                                 Default: 32 Gb
+
+    --cpus INT              Number of processors made available to a single
+                                process. 
+                                Default: 4
 ```
 
 ### `--genome_size`
@@ -77,28 +84,18 @@ Throughout the Bactopia workflow a genome size is used for various tasks. By def
 !!! error "Mash may not be the most accurate estimate"
     Mash is very convenient to quickly estimate a genome size, but it may not be the most accurate in all cases and will differ between samples. It is recommended that when possible a known genome size or one based off completed genomes should be used. 
 
-### `--max_cpus` vs `--cpus`
-By default when Nextflow executes, it uses all available cpus to queue up processes. As you might imagine, if you are on a single server with multiple users, this approach of using all cpus might annoy other users! (Whoops sorry!) To circumvent this feature, two parmeters have been included `--max_cpus` and `--cpus`.
-
-```
-    --max_cpus INT          The maximum number of processors this workflow
-                                should have access to at any given moment
-                                Default: 1
-
-    --cpus INT              Number of processors made available to a single
-                                process. If greater than "--max_cpus" it
-                                will be set equal to "--max_cpus"
-                                Default: 1
-```
-
-What `--max_cpus` does is specify to Nextflow the maximum number of cpus it is allowed to occupy at any given time. `--cpus` on the other hand, specifies how many cpus any given step (qc, assembly, annotation, etc...) can occupy. 
-
-By default `--max_cpus` is set to 1 and if `--cpus` is set to a value greater than `--max_cpus` it will be set equal to `--max_cpus`. This appoach errs on the side of caution, by not occupying all cpus on the server without the users consent!
-
 
 ## Helpers
 The following parameters are useful to test to test input parameters.
 ```
+    --infodir DIR           Directory to write Nextflow summary files to
+                                Default: ./bactopia-info
+
+    --condadir DIR          Directory to Nextflow should use for Conda environments
+                                Default: Bactopia's Nextflow directory
+
+    --nfdir                 Print directory Nextflow has pulled Bactopia to
+
     --available_datasets    Print a list of available datasets found based
                                 on location given by "--datasets"
 
@@ -228,7 +225,7 @@ It is important to note, not all of the available parameters for each and every 
 ### Assembly
 ```
     --shovill_ram INT       Try to keep RAM usage below this many GB
-                                Default: 32
+                                Default: 6 GB
 
     --assembler STR         Assembler: megahit velvet skesa spades
                                 Default: skesa
@@ -276,6 +273,9 @@ It is important to note, not all of the available parameters for each and every 
 
 ### Counting 31mers
 ```
+    --cortex_ram INT        Try to keep RAM usage below this many GB
+                                Default: 8 GB
+
     --keep_singletons       Keep all counted 31-mers
                                 Default: Filter out singletons
 ```
@@ -390,6 +390,9 @@ It is important to note, not all of the available parameters for each and every 
 
 ### Minmer Sketch
 ```
+    --minmer_ram INT        Try to keep RAM usage below this many GB
+                                Default: 5 GB
+
     --mash_sketch INT       Sketch size. Each sketch will have at most this
                                 many non-redundant min-hashes.
                                 Default: 10000
@@ -402,6 +405,9 @@ It is important to note, not all of the available parameters for each and every 
 
 ### Quality Control 
 ```
+    --qc_ram INT            Try to keep RAM usage below this many GB
+                                Default: 3 GB
+
     --adapters FASTA        Illumina adapters to remove
                                 Default: BBmap adapters
 
@@ -502,7 +508,7 @@ It is important to note, not all of the available parameters for each and every 
 ### Variant Calling
 ```
     --snippy_ram INT        Try and keep RAM under this many GB
-                                Default: 8
+                                Default: 8 GB
 
     --mapqual INT           Minimum read mapping quality to consider
                                 Default: 60

--- a/main.nf
+++ b/main.nf
@@ -922,7 +922,6 @@ def check_input_params() {
         error += 1
     }
 
-    error += is_positive_integer(params.max_cpus, 'max_cpus')
     error += is_positive_integer(params.cpus, 'cpus')
     error += is_positive_integer(params.max_time, 'max_time')
     error += is_positive_integer(params.max_memory, 'max_memory')

--- a/main.nf
+++ b/main.nf
@@ -3,8 +3,8 @@ import groovy.json.JsonSlurper
 import groovy.text.SimpleTemplateEngine
 import java.nio.file.Path
 import java.nio.file.Paths
-PROGRAM_NAME = manifest.name
-VERSION = manifest.version
+PROGRAM_NAME = workflow.manifest.name
+VERSION = workflow.manifest.version
 
 // Validate parameters
 if (params.help || params.help_all) print_usage();
@@ -1153,7 +1153,7 @@ def basic_help() {
                                     Default: Mash estimate
 
         --outdir DIR            Directory to write results to
-                                    Default ${params.outdir}
+                                    Default: ${params.outdir}
 
         --max_time INT          The maximum number of minutes a job should run before being halted.
                                     Default: ${params.max_time} minutes
@@ -1161,21 +1161,16 @@ def basic_help() {
         --max_memory INT        The maximum amount of memory (Gb) allowed to a single process.
                                     Default: ${params.max_memory} Gb
 
-        --max_cpus INT          The maximum number of processors this workflow
-                                    should have access to at any given moment
-                                    Default: ${params.max_cpus}
-
         --cpus INT              Number of processors made available to a single
-                                    process. If greater than "--max_cpus" it
-                                    will be set equal to "--max_cpus"
+                                    process.
                                     Default: ${params.cpus}
 
     Nextflow Related Parameters:
         --infodir DIR           Directory to write Nextflow summary files to
-                                    Default ${params.infodir}
+                                    Default: ${params.infodir}
 
         --condadir DIR          Directory to Nextflow should use for Conda environments
-                                    Default ${params.infodir}
+                                    Default: Bactopia's Nextflow directory
 
         --nfdir                 Print directory Nextflow has pulled Bactopia to
 
@@ -1228,7 +1223,7 @@ def full_help() {
 
     QC Reads Parameters:
         --qc_ram INT            Try to keep RAM usage below this many GB
-                                    Default: ${params.qc_ram}
+                                    Default: ${params.qc_ram} GB
 
         --min_basepairs INT     The minimum amount of input sequenced basepairs required
                                     to continue downstream analyses.
@@ -1332,7 +1327,7 @@ def full_help() {
 
     Assembly Parameters:
         --shovill_ram INT       Try to keep RAM usage below this many GB
-                                    Default: ${params.shovill_ram}
+                                    Default: ${params.shovill_ram} GB
 
         --assembler STR         Assembler: megahit velvet skesa spades
                                     Default: ${params.assembler}
@@ -1362,7 +1357,8 @@ def full_help() {
 
     Count 31mers Parameters:
         --cortex_ram INT        Try to keep RAM usage below this many GB
-                                    Default: ${params.cortex_ram}
+                                    Default: ${params.cortex_ram} GB
+
         --keep_singletons       Keep all counted 31-mers
                                     Default: Filter out singletons
 
@@ -1402,7 +1398,8 @@ def full_help() {
 
     Minmer Query Parameters:
         --minmer_ram INT        Try to keep RAM usage below this many GB
-                                    Default: ${params.qc_ram}
+                                    Default: ${params.minmer_ram} GB
+
         --screen_w              Winner-takes-all strategy for identity estimates.
                                     After counting hashes for each query, hashes
                                     that appear in multiple queries will be
@@ -1463,7 +1460,7 @@ def full_help() {
 
     Call Variant Parameters:
         --snippy_ram INT        Try and keep RAM under this many GB
-                                    Default: ${params.snippy_ram}
+                                    Default: ${params.snippy_ram} GB
 
         --mapqual INT           Minimum read mapping quality to consider
                                     Default: ${params.mapqual}

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,28 +1,71 @@
 // main script name
 manifest {
     author = 'Robert A. Petit III'
-    name = 'Bactopia'
+    name = 'bactopia'
     homePage = 'https://github.com/bactopia/bactopia'
-    description = 'A generic pipeline for bacterial genomics.'
+    description = 'An extensive workflow for processing Illumina sequencing of bacterial genomes.'
     mainScript = 'main.nf'
     version = '1.2.0'
     nextflowVersion = '>=19'
 }
 
+// Includes
+includeConfig "${baseDir}/conf/params.config"
+includeConfig "${baseDir}/conf/base.config"
+includeConfig "${baseDir}/conf/profiles.config"
+
 // Reporting configuration
-timeline.enabled = true
-report.enabled = true
+timeline {
+    enabled = true
+    file = "${params.infodir}/bactopia-timeline.html"
+}
+
+report {
+    enabled = true
+    file = "${params.infodir}/bactopia-report.html"
+}
+
 trace {
     enabled = true
+    file = "${params.infodir}/bactopia-trace.txt"
     fields = 'task_id,hash,native_id,process,tag,name,status,exit,module,container,cpus,time,disk,memory,attempt,start,complete,duration,realtime,queue,%cpu,%mem,rss,vmem'
 }
+
 
 // Process configuration
 process.ext.template = {"${task.process}.sh"}
 
-// Conda configuration
-conda.cacheDir = "${baseDir}/conda/cache/envs"
-
-// Includes
-includeConfig "${baseDir}/conf/params.config"
-includeConfig "${baseDir}/conf/profiles.config"
+// Function to ensure that resource requirements don't go beyond a maximum limit
+// Source: https://github.com/nf-core/rnaseq/blob/master/nextflow.config
+def check_max(obj, type) {
+    if (type == 'memory') {
+        try {
+            max_memory = (params.max_memory).GB
+            if (obj.compareTo(max_memory as nextflow.util.MemoryUnit) == 1)
+                return max_memory as nextflow.util.MemoryUnit
+            else
+                return obj
+        } catch (all) {
+            println "ERROR - Max memory '${params.max_memory} GB' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'time') {
+        try {
+            max_time = (params.max_time).m
+            if (obj.compareTo(max_time as nextflow.util.Duration) == 1)
+                return max_time as nextflow.util.Duration
+            else
+            return obj
+        } catch (all) {
+            println "ERROR - Max time '${params.max_time} minutes' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'cpus') {
+        try {
+            return Math.min(obj, params.max_cpus as int)
+        } catch (all) {
+            println "ERROR - Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+            return obj
+        }
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
     homePage = 'https://github.com/bactopia/bactopia'
     description = 'An extensive workflow for processing Illumina sequencing of bacterial genomes.'
     mainScript = 'main.nf'
-    version = '1.2.0'
+    version = '1.2.1'
     nextflowVersion = '>=19'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,9 +62,9 @@ def check_max(obj, type) {
         }
     } else if (type == 'cpus') {
         try {
-            return Math.min(obj, params.max_cpus as int)
+            return Math.min(obj, params.cpus as int)
         } catch (all) {
-            println "ERROR - Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+            println "ERROR - Max cpus '${params.cpus}' is not valid! Using default value: $obj"
             return obj
         }
     }

--- a/templates/antimicrobial_resistance.sh
+++ b/templates/antimicrobial_resistance.sh
@@ -13,14 +13,14 @@ amrfinder -n !{sample}.ffn \
           --ident_min !{params.amr_ident_min} \
           --coverage_min !{params.amr_coverage_min} \
           --translation_table !{params.amr_translation_table} \
-          --threads !{cpus} !{organism_gene} !{plus} !{report_common}
+          --threads !{task.cpus} !{organism_gene} !{plus} !{report_common}
 
 amrfinder -p !{sample}.faa \
           -o antimicrobial_resistance/!{sample}-protein-report.txt \
           --ident_min !{params.amr_ident_min} \
           --coverage_min !{params.amr_coverage_min} \
           --translation_table !{params.amr_translation_table} \
-          --threads !{cpus} !{organism_protein} !{plus} !{report_common}
+          --threads !{task.cpus} !{organism_protein} !{plus} !{report_common}
 
 if [[ !{params.compress} == "true" ]]; then
     rm !{sample}.faa !{sample}.ffn


### PR DESCRIPTION
## v1.2.1 bactopia/bactopia "Fruit Punches" - 2019/10/17

### `Added`
- `bactopia build` to build Conda environments
- Version info pulled from nextflow.config
- Set default values resource allocations
- Documentation on new changes
- Automatic building of Conda environments, if none exist
- `--nfdir` to determine where bactopia is being run from

### `Fixed`
- Neverending typos
- `--datasets` now, not `--dataset` <-(Typo)
- path for outputing Nextflow reports
- Typo in antimicrobial_resistance.sh (task.cpus not cpus)
- `--species` is now consistent between `bactopia` and `bactopia datasets`
- Bug when checking if specific species dataset exists, but no species datasets exist
- Cleaned up version update script
- Cleaned up usage

### `Removed`
- `--max_cpus` ability to limit total cores used, access to config is being deprecated in Nextflow
- `--max_cpus` since it is redudant to `--cpus` now