### PR TITLE
Fix undefined var $name in templates/plasmid_blast.sh

### DIFF
--- a/templates/plasmid_blast.sh
+++ b/templates/plasmid_blast.sh
@@ -20,6 +20,8 @@ fi
 
 file_size=`cat !{gunzip_genes} | wc -c`
 block_size=$(( file_size / !{task.cpus} / 2 ))
+name=!{genes}
+name="${name%.*}"
 mkdir -p temp_json
 cat !{gunzip_genes} | \
 parallel --gnu --plain -j !{task.cpus} --block ${block_size} --recstart '>' --pipe \


### PR DESCRIPTION
Plasmid BLAST failed because of the undefined variable `$name`. To be honest I am not sure what `!{genes}` represents :) but I tested this and the output looks fine.

Please take a better look at what `!{genes}` is replaced by before merging!