### PR TITLE
Fix to setting assembly_level on download command; added options for …

### DIFF
--- a/bin/bactopia/bactopia-datasets.py
+++ b/bin/bactopia/bactopia-datasets.py
@@ -599,7 +599,7 @@ def setup_prokka(request, available_datasets, outdir, force=False,
                     continue
 
             execute((f'ncbi-genome-download bacteria -A {accession_file} '
-                    f'-l complete -o {prokka_dir}/genomes -F genbank -r 80 '
+                    f'-l {assembly_level} -o {prokka_dir}/genomes -F genbank -r 80 '
                     f'-m {prokka_dir}/ncbi-metadata.txt'))
 
             # Extract information from Genbank files
@@ -1019,7 +1019,7 @@ if __name__ == '__main__':
     )
     group3.add_argument(
         '--assembly_level', default='complete', type=str,
-        choices=['all', 'complete', 'chromosome', 'scaffold', 'contig'],
+        choices=['all', 'complete', 'chromosome', 'scaffold', 'contig', 'complete,chromosome', 'chromosome,complete'],
         help=('Assembly levels of genomes to download (Default: complete).')
     )
     group3.add_argument(


### PR DESCRIPTION
Hi! I have really been enjoying using this tool. I started a new project on Treponema pallidum and I wanted to download datasets that included assemblies on the chromosome level but was running into an issue. 

```
bactopia datasets  --species "Treponema pallidum" \
                                 --include_genus \
                                 --assembly_level chromosome
```

```
2022-04-14 15:01:45:root:INFO - Treponema pallidum verified in ENA Taxonomy database
2022-04-14 15:01:45:root:INFO - Setting up Ariba datasets
2022-04-14 15:01:45:root:INFO - vfdb_core (./datasets/ariba/vfdb_core) exists, skipping
2022-04-14 15:01:45:root:INFO - card (./datasets/ariba/card) exists, skipping
2022-04-14 15:01:45:root:INFO - plasmidfinder (./datasets/ariba/plasmidfinder) exists, skipping
2022-04-14 15:01:45:root:INFO - Setting up pre-computed Genbank/Refseq minmer datasets
2022-04-14 15:01:45:root:INFO - ./datasets/minmer/sourmash-genbank-k21.json.gz exists, skipping
2022-04-14 15:01:45:root:INFO - ./datasets/minmer/sourmash-genbank-k31.json.gz exists, skipping
2022-04-14 15:01:45:root:INFO - ./datasets/minmer/sourmash-genbank-k51.json.gz exists, skipping
2022-04-14 15:01:45:root:INFO - ./datasets/minmer/mash-refseq-k21.msh exists, skipping
2022-04-14 15:01:45:root:INFO - Setting up antimicrobial resistance datasets
2022-04-14 15:01:45:root:INFO - Setting up latest AMRFinder+ database
2022-04-14 15:02:00:root:INFO - AMRFinder+ database saved to ./datasets/antimicrobial-resistance/amrfinderdb.tar.gz
2022-04-14 15:02:00:root:INFO - Setting up MLST datasets
2022-04-14 15:02:00:root:INFO - Setting up default MLST schema for Treponema pallidum
2022-04-14 15:02:00:root:INFO - Creating Ariba MLST dataset
2022-04-14 15:02:21:root:INFO - Creating BLAST MLST dataset
2022-04-14 15:02:21:root:INFO - Setting up custom Prokka proteins
2022-04-14 15:02:21:root:INFO - Setting up custom Prokka proteins for Treponema pallidum
2022-04-14 15:02:21:root:INFO - Downloading genomes (assembly level: chromosome)
2022-04-14 15:02:23:root:INFO - There are less available genomes than the given limit (2500), downloading all.
External command failed with exit code 1!

Command:
bash -c 'ncbi-genome-download bacteria -A ./datasets/species-specific/treponema-pallidum/annotation/genomes/accessions.txt -l complete -o ./datasets/species-specific/treponema-pallidum/annotation/genomes -F genbank -r 80 -m ./datasets/species-specific/treponema-pallidum/annotation/ncbi-metadata.txt'

Standard error:
ERROR: No downloads matched your filter. Please check your options.
```
And I noticed the discrepancy between "2022-04-14 15:02:21:root:INFO - Downloading genomes (assembly level: ***chromosome***)" and "bash -c 'ncbi-genome-download bacteria -A ......accessions.txt -l ***complete*** "

And when I looked through the code I saw that when you created the option to specify assembly level there was one place where you didn't change the `"complete"` to `{assembly_level}` . So the accessions were being downloaded correctly but when the actual download command was run it was always set to complete. 

Also for whatever reason, the Treponema genomes I was interested in are at both complete and chromosome level but I didn't want to include the scaffold and contig level assemblies so instead of doing `all` I added to the choices for the arg parse to allow for specifying also just complete, chromosome (and since I never remember which I listed first I added both complete,chromosome and chromosome,complete), and giving multiple choices is allowed by `ncbi-genome-download`. I didn't think there would be a lot of cases where people were interested in the other combos so I didn't add all possible choice combos. 

Nick 