### PR TITLE
Fix in call_variants for ncbi download, removed assembly level arg;

### DIFF
--- a/modules/local/bactopia/call_variants/main.nf
+++ b/modules/local/bactopia/call_variants/main.nf
@@ -56,7 +56,7 @@ process CALL_VARIANTS {
         printf "accession\\tdistance\\tlatest_accession\\tupdated\\n" > mash-dist.txt
         select-references.py distances.txt 1 !{tie_break} >> mash-dist.txt
         grep -v distance mash-dist.txt | cut -f3 > download-list.txt
-        ncbi-genome-download bacteria -l complete -o ./ -F genbank -p !{task.cpus} -A download-list.txt \
+        ncbi-genome-download bacteria -o ./ -F genbank -p !{task.cpus} -A download-list.txt \
             -r !{params.max_retry} !{no_cache}
 
         # Move and uncompress genomes


### PR DESCRIPTION
Sorry, I missed one other place from yesterday for the assembly level hard coding, in the `call_variants` modules it was still hardcoded to be `-l complete`, didn't notice until I ran through the full pipeline. Since the genome to be downloaded is being auto-determined and fed into `ncbi-genome-download` I figured just remove the assembly argument completely. 

Nick 
