### PR TITLE
Update call_variants.yml

### DIFF
--- a/conda/linux/call_variants.yml
+++ b/conda/linux/call_variants.yml
@@ -86,7 +86,7 @@ dependencies:
   - ncbi-genome-download=0.3.1
   - ncurses=6.3
   - numpy=1.21.6
-  - openjdk=17.0.3
+  - openjdk=11.0.13
   - openssl=1.1.1s
   - paml=4.9
   - parallel=20221122


### PR DESCRIPTION
Changing java version from 17 to 11 debugs the java warning message: [0.006s][warning][os,container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset, skipping /dev/cpuset. that gets printed into VCF files and breaks the pipeline in the variant calling step and annotation.