### PR TITLE
add functionality for user defined database for emmtyper module

### DIFF
--- a/modules/nf-core/emmtyper/main.nf
+++ b/modules/nf-core/emmtyper/main.nf
@@ -34,8 +34,6 @@ process EMMTYPER {
         gzip -c -d $fasta > $fasta_name
     fi
 
-    echo $db
-
     # Conditionally add the database if it is provided by user
     if [ "$db" == "" ]; then
         emmtyper \\
@@ -43,7 +41,6 @@ process EMMTYPER {
             $fasta_name \\
             > ${prefix}.tsv
     else
-
         # Make the blast database
         makeblastdb -in $db -dbtype nucl
 
@@ -52,6 +49,9 @@ process EMMTYPER {
             $options.args \\
             $fasta_name \\
             > ${prefix}.tsv
+
+        # Remove the blast database
+        rm $db*
     fi
 
     # If 'tmp' is not in $fasta_name, remove '.tmp' from the output files contents

--- a/modules/nf-core/emmtyper/main.nf
+++ b/modules/nf-core/emmtyper/main.nf
@@ -54,6 +54,11 @@ process EMMTYPER {
             > ${prefix}.tsv
     fi
 
+    # If 'tmp' is not in $fasta_name, remove '.tmp' from the output files contents
+    if [ $fasta_name != *.tmp* ]; then
+        sed -i 's/.tmp\t/\t/g' ${prefix}.tsv
+    fi
+
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/emmtyper/params.config
+++ b/modules/nf-core/emmtyper/params.config
@@ -5,6 +5,7 @@ This file includes default parameter values.
 params {
     // emmtyper
     emmtyper_wf = "blast"
+    blast_db = null
     cluster_distance = 500
     percid = 95
     culling_limit = 5

--- a/modules/nf-core/emmtyper/params.json
+++ b/modules/nf-core/emmtyper/params.json
@@ -19,6 +19,11 @@
                     "fa_icon": "fas fa-expand-arrows-alt",
                     "enum": ["blast", "pcr"]
                 },
+                "blast_db": {
+                    "type": "string",
+                    "description": "Path to custom EMM BLAST DB.",
+                    "fa_icon": "fas fa-file-alt"
+                },
                 "cluster_distance": {
                     "type": "integer",
                     "default": 500,

--- a/subworkflows/local/emmtyper/main.nf
+++ b/subworkflows/local/emmtyper/main.nf
@@ -15,6 +15,7 @@ options.args = [
     "--min-good ${params.min_good}",
     "--max-size ${params.max_size}"
 ].join(' ').replaceAll("\\s{2,}", " ").trim()
+BLAST_DB = params.blast_db ? file(params.blast_db) : []
 
 include { EMMTYPER as EMMTYPER_MODULE } from '../../../modules/nf-core/emmtyper/main' addParams( options: options )
 include { CSVTK_CONCAT } from '../../../modules/nf-core/csvtk/concat/main' addParams( options: [logs_subdir: 'emmtyper-concat', process_name: params.merge_folder] )
@@ -26,7 +27,8 @@ workflow EMMTYPER {
     main:
     ch_versions = Channel.empty()
 
-    EMMTYPER_MODULE(fasta)
+    EMMTYPER_MODULE(fasta, BLAST_DB)
+
     ch_versions = ch_versions.mix(EMMTYPER_MODULE.out.versions.first())
 
     // Merge results

--- a/subworkflows/local/emmtyper/test.yml
+++ b/subworkflows/local/emmtyper/test.yml
@@ -36,7 +36,7 @@
     - path: bactopia/GCF_006364235/tools/emmtyper/logs/nf-emmtyper.log
       contains: ['emmtyper', 'Finished']
     - path: bactopia/GCF_006364235/tools/emmtyper/logs/nf-emmtyper.out
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
+      md5sum: 68b329da9893e34099c7d8ad5cb9c940
     - path: bactopia/GCF_006364235/tools/emmtyper/logs/nf-emmtyper.run
       contains: ['NXF_DEBUG', '$NXF_ENTRY']
     - path: bactopia/GCF_006364235/tools/emmtyper/logs/nf-emmtyper.sh

--- a/subworkflows/local/genotyphi/meta.yml
+++ b/subworkflows/local/genotyphi/meta.yml
@@ -52,7 +52,7 @@ docs:
       of Mykrobe.
   introduction: |
       The `genotyphi` module uses [GenoTyphi](https://github.com/typhoidgenomics/genotyphi) to
-      call Typhi lineages, AMR determines and plasmid markers in Salmonella Typhi samples.
+      call Typhi lineages, AMR determinants, and plasmid markers in Salmonella Typhi samples.
       Samples are first processed by [Mykrobe](https://github.com/Mykrobe-tools/mykrobe) using `mykrobe predict`
       with `typhi` specified as the species. Then the Mykrobe results are then processed by the
       [parse_typhi_mykrobe.py](https://github.com/typhoidgenomics/genotyphi/blob/main/typhimykrobe/parse_typhi_mykrobe.py)


### PR DESCRIPTION
Hey Rob,

Below is discussed emmtyper PR.

Some awkwardness around blast databases requiring multiple files rather than just the fasta, so I opted to just make the blast database inside the module seeing as blast is a dependency. Doesn't add any noticeable computational time so I think it is the best solution, let me know if you feel otherwise.