### PR TITLE
Bugfix/prefix abritamr

### DIFF
--- a/modules/abritamr/run/main.nf
+++ b/modules/abritamr/run/main.nf
@@ -38,18 +38,18 @@ process ABRITAMR_RUN {
 
     abritamr run \\
         --contigs $fasta_name \\
-        --prefix results \\
+        --prefix $prefix \\
         $task.ext.args \\
         --jobs $task.cpus
 
     # Rename output files to prevent name collisions
-    mv results/summary_matches.txt ./${prefix}.summary_matches.txt
-    mv results/summary_partials.txt ./${prefix}.summary_partials.txt
-    mv results/summary_virulence.txt ./${prefix}.summary_virulence.txt
-    mv results/amrfinder.out ./${prefix}.amrfinder.out
+    mv ${prefix}/summary_matches.txt ./${prefix}.summary_matches.txt
+    mv ${prefix}/summary_partials.txt ./${prefix}.summary_partials.txt
+    mv ${prefix}/summary_virulence.txt ./${prefix}.summary_virulence.txt
+    mv ${prefix}/amrfinder.out ./${prefix}.amrfinder.out
     if [ -f results/abritamr.txt ]; then
         # This file is not always present
-        mv results/abritamr.txt ./${prefix}.abritamr.txt
+        mv ${prefix}/abritamr.txt ./${prefix}.abritamr.txt
     fi
 
     # Cleanup


### PR DESCRIPTION
**Bugfix: abritamr prefix uses sample ID; fix output paths to avoid collisions**

Description

Replace static --prefix results with a sample-specific prefix so the Isolate field in abritamr.txt reflects the actual sample (e.g., ABC-111) instead of “results”.

Adjust output renames from results/... to ${prefix}/... to match abritamr’s per-prefix output directory and prevent filename collisions across runs.

Before: Isolate = “results” leading to incorrect labels and collisions in merged-results/abritamr.tsv.

After: Isolate = actual sample ID; unique per-sample filenames like ${prefix}.abritamr.txt, summaries, and amrfinder.out.

Impact

Fixes incorrect Isolate naming and eliminates cross-sample filename collisions; no schema changes to downstream summaries, only corrected naming.

Testing

Ran with multiple samples; verified abritamr.txt now shows the sample ID and files are emitted under ${prefix}/ then renamed to ${prefix}.* without conflicts.