### PR TITLE
Fix merged output file error in emmtyper workflow

### DIFF
--- a/subworkflows/local/emmtyper/main.nf
+++ b/subworkflows/local/emmtyper/main.nf
@@ -18,7 +18,7 @@ options.args = [
 BLASTDB = params.emmtyper_blastdb ? file(params.emmtyper_blastdb) : []
 
 include { EMMTYPER as EMMTYPER_MODULE } from '../../../modules/nf-core/emmtyper/main' addParams( options: options )
-include { CSVTK_CONCAT } from '../../../modules/nf-core/csvtk/concat/main' addParams( options: [logs_subdir: 'emmtyper-concat', process_name: params.merge_folder] )
+include { CSVTK_CONCAT } from '../../../modules/nf-core/csvtk/concat/main' addParams( options: [args: '--no-header-row', logs_subdir: 'emmtyper-concat', process_name: params.merge_folder] )
 
 workflow EMMTYPER {
     take:


### PR DESCRIPTION
Hi Robert, 

Love Bactopia and use it all the time. I've noticed that when the emmtpyer workflow calls csvtk_concat, the output merged file (emmtyper.tsv) only ever contains a single line regardless of the number of samples. Adding `args: '--no-header-row'` to the options (as per other workflows like mlst) in subworkflows/local/emmtyper/main.nf fixed this in my local install.

Thanks for your work on this tool (and for reviewing my first pull request). 
August